### PR TITLE
An error via using long sequence datasets

### DIFF
--- a/src/cl_dataset.py
+++ b/src/cl_dataset.py
@@ -180,7 +180,7 @@ class CLInstructions(datasets.GeneratorBasedBuilder):
         
         return instances
     
-    def load_LongSeq_dataset(self,labels_path, dataset_path, dataset_name, sampling_strategy, max_num_instances, subset):
+    def load_LongSeq_dataset(self, dataset_path,labels_path, dataset_name, sampling_strategy, max_num_instances, subset):
 
         data = self._load_dataset(dataset_path)
         print(list(data.keys()))

--- a/src/cl_dataset.py
+++ b/src/cl_dataset.py
@@ -180,7 +180,7 @@ class CLInstructions(datasets.GeneratorBasedBuilder):
         
         return instances
     
-    def load_LongSeq_dataset(self, dataset_path, dataset_name, sampling_strategy, max_num_instances, subset):
+    def load_LongSeq_dataset(self,labels_path, dataset_path, dataset_name, sampling_strategy, max_num_instances, subset):
 
         data = self._load_dataset(dataset_path)
         print(list(data.keys()))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/data/home/wangxq/.conda/envs/cl2/lib/python3.10/site-packages/datasets/builder.py", line 1676, in _prepare_split_single
    for key, record in generator:
  File "/data/home/wangxq/.cache/huggingface/modules/datasets_modules/datasets/cl_dataset/51be65703a771daa00a46d4416772056e921f8ee0d14cecf012397ce192346cc/cl_dataset.py", line 317, in _generate_examples
    for sample in load_func(ds_path, labels_path, ds_name, sampling_strategy, max_num_instances_per_task,
TypeError: CLInstructions.load_LongSeq_dataset() takes 6 positional arguments but 7 were given

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/home/wangxq/moe_lora/random_noise/SAPT/src/t5_merge_train.py", line 657, in <module>
    main()
  File "/data/home/wangxq/moe_lora/random_noise/SAPT/src/t5_merge_train.py", line 445, in main
    raw_datasets = load_dataset(
  File "/data/home/wangxq/.conda/envs/cl2/lib/python3.10/site-packages/datasets/load.py", line 2153, in load_dataset
    builder_instance.download_and_prepare(
  File "/data/home/wangxq/.conda/envs/cl2/lib/python3.10/site-packages/datasets/builder.py", line 954, in download_and_prepare
    self._download_and_prepare(
  File "/data/home/wangxq/.conda/envs/cl2/lib/python3.10/site-packages/datasets/builder.py", line 1717, in _download_and_prepare
    super()._download_and_prepare(
  File "/data/home/wangxq/.conda/envs/cl2/lib/python3.10/site-packages/datasets/builder.py", line 1049, in _download_and_prepare
    self._prepare_split(split_generator, **prepare_split_kwargs)
  File "/data/home/wangxq/.conda/envs/cl2/lib/python3.10/site-packages/datasets/builder.py", line 1555, in _prepare_split
    for job_id, done, content in self._prepare_split_single(
  File "/data/home/wangxq/.conda/envs/cl2/lib/python3.10/site-packages/datasets/builder.py", line 1712, in _prepare_split_single
    raise DatasetGenerationError("An error occurred while generating the dataset") from e
datasets.builder.DatasetGenerationError: An error occurred while generating the dataset
```




i solve it by adding  a postitional aruguements on func **load_LongSeq_dataset**